### PR TITLE
fix(app.src): use git tag for app version

### DIFF
--- a/src/pbkdf2.app.src
+++ b/src/pbkdf2.app.src
@@ -1,6 +1,6 @@
 {application, pbkdf2, [
     {description, "Erlang PBKDF2 Key Derivation Function"},
-    {vsn, "2.0.2"},
+    {vsn, "git"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {modules, [pbkdf2]},


### PR DESCRIPTION
2.0.3 is already released without version bump in app.src.
will release 2.0.4 after this merge.